### PR TITLE
Check not found page

### DIFF
--- a/src/mixins/jobDetailsMetaInfo.js
+++ b/src/mixins/jobDetailsMetaInfo.js
@@ -1,6 +1,6 @@
 export default {
   metaInfo() {
-    if (this.isLoading) {
+    if (this.isLoading || this.notFound) {
       return {};
     }
 


### PR DESCRIPTION
Do not run jobDetailsMetaInfo when catch error fetching the post data in JobDetails page.

![not_found_page](https://user-images.githubusercontent.com/9579731/59151969-4d409c80-8a44-11e9-8fbc-96fe83f7294f.jpeg)
