### PR TITLE
Close Subscribe component after user subscribed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -43,6 +43,9 @@ export default {
   methods: {
     ...mapActions(['subscribe']),
     handleSubscribe() {
+      if (this.isClosed) {
+        return false;
+      }
       this.isClosed = true;
       this.frequency = this.frequencyModel.value;
       const { frequency, name, email } = this;

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -44,7 +44,6 @@ export default {
     ...mapActions(['subscribe']),
     handleSubscribe() {
       this.frequency = this.frequencyModel.value;
-      console.log("Handling subscribe");
       const { frequency, name, email } = this;
 
       this.subscribe({ frequency, name, email })

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -56,7 +56,7 @@ export default {
           this.showDialog('Hata: Kaydınız gerçekleştirilemedi.', `<ul>${details || ''}</ul>`);
         });
     },
-    handleEnter(){
+    handleEnter() {
       this.handleSubscribe();
     },
     showDialog(title, text, buttons = [{ title: 'Kapat' }]) {
@@ -88,8 +88,8 @@ export default {
     </div>
     <span>olarak almak için</span>
     <input type="text" v-model="name" placeholder="İsim soyisim" class="username">
-    <input @keyup.enter="handleEnter" type="text" v-model="email" placeholder="Email">
-    <button class="button" @click="handleSubscribe">
+    <input @keyup.enter.once="handleEnter" type="text" v-model="email" placeholder="Email">
+    <button class="button" @click.once="handleSubscribe">
       Abone ol!
     </button>
     <span

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -44,7 +44,7 @@ export default {
     ...mapActions(['subscribe']),
     handleSubscribe() {
       if (this.isClosed) {
-        return false;
+        return;
       }
       this.isClosed = true;
       this.frequency = this.frequencyModel.value;

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -74,31 +74,29 @@ export default {
     :class="{ fixed: fixed }"
     class="subscribe-widget"
   >
-    <form @submit.prevent="handleSubscribe">
-      <span>Güncel iş ilanlarını</span>
-      <div class="subscribe--select">
-        <multiselect
-          v-model="frequencyModel"
-          :options="frequencyOptions"
-          label="text"
-          :searchable="false"
-          :close-on-select="true"
-        />
-      </div>
-      <span>olarak almak için</span>
-      <input type="text" v-model="name" placeholder="İsim soyisim" class="username">
-      <input type="text" v-model="email" placeholder="Email">
-      <button class="button" @click="handleSubscribe">
-        Abone ol!
-      </button>
-      <span
-        v-if="fixed"
-        class="close"
-        @click="close"
-      >
-        Bir daha gösterme :(
-      </span>
-    </form>
+    <span>Güncel iş ilanlarını</span>
+    <div class="subscribe--select">
+      <multiselect
+        v-model="frequencyModel"
+        :options="frequencyOptions"
+        label="text"
+        :searchable="false"
+        :close-on-select="true"
+      />
+    </div>
+    <span>olarak almak için</span>
+    <input type="text" v-model="name" placeholder="İsim soyisim" class="username">
+    <input @keyup.enter="handleSubscribe" type="text" v-model="email" placeholder="Email">
+    <button class="button" @click="handleSubscribe">
+      Abone ol!
+    </button>
+    <span
+      v-if="fixed"
+      class="close"
+      @click="close"
+    >
+      Bir daha gösterme :(
+    </span>
   </div>
 </template>
 

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -47,27 +47,18 @@ export default {
 
       const { frequency, name, email } = this;
 
-      this.subscribe({
-        frequency,
-        name,
-        email,
-      })
+      this.subscribe({ frequency, name, email })
         .then(() => {
           this.showDialog('Email listesine kaydınız gerçekleştirildi.');
           this.close();
         })
         .catch((e) => {
-          const details = Object.values(e.response.data.errors || [])
-            .map(r => `<li>${r[0]}</li>`);
+          const details = Object.values(e.response.data.errors || []).map(r => `<li>${r[0]}</li>`);
           this.showDialog('Hata: Kaydınız gerçekleştirilemedi.', `<ul>${details || ''}</ul>`);
         });
     },
     showDialog(title, text, buttons = [{ title: 'Kapat' }]) {
-      this.$modal.show('dialog', {
-        title,
-        text,
-        buttons,
-      });
+      this.$modal.show('dialog', { title, text, buttons });
     },
     close() {
       this.isClosed = true;
@@ -112,11 +103,12 @@ export default {
 </template>
 
 <style lang="scss">
-  .subscribe-widget {
-    padding: 10px;
-    box-sizing: border-box;
-    font-size: 16px;
-    text-align: center;
+.subscribe-widget {
+  padding: 10px;
+  box-sizing: border-box;
+  font-size: 16px;
+  text-align: center;
+
 
   .subscribe--select {
     text-align: left;
@@ -135,83 +127,83 @@ export default {
     border-top: 1px solid #474646;
     line-height: 50px;
 
-      input[type=text] {
-        margin-right: 6px;
-        width: 120px;
-        display: inline;
-
-        &.username {
-          margin-left: 6px;
-        }
-      }
-
-      select,
-      .subscribe--select {
-        display: inline-block;
-        width: 100px;
-        margin: 0 6px;
-        color: #202020;
-      }
-
-      .close {
-        display: block;
-        color: #5c5c5c;
-        font-size: 12px;
-        position: absolute;
-        top: 10px;
-        right: 10px;
-        line-height: 12px;
-        cursor: pointer;
-
-        &:hover {
-          color: #ccc;
-        }
-      }
-    }
-
     input[type=text] {
-      padding: 11px 10px;
+      margin-right: 6px;
+      width: 120px;
+      display: inline;
+
+      &.username {
+        margin-left: 6px;
+      }
     }
 
-    select {
-      height: 42px;
+    select,
+    .subscribe--select {
+      display: inline-block;
+      width: 100px;
+      margin: 0 6px;
+      color: #202020;
     }
 
-    button {
+    .close {
+      display: block;
+      color: #5c5c5c;
+      font-size: 12px;
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      line-height: 12px;
+      cursor: pointer;
+
       &:hover {
-        background-color: #26ae61;
+        color: #ccc;
       }
     }
   }
 
-  @media only screen and (max-width: 768px) {
-    #footer {
-      padding-bottom: 10px !important;
-    }
-
-    .subscribe-widget.fixed {
-      display: none;
-    }
+  input[type=text] {
+    padding: 11px 10px;
   }
 
-  @media only screen and (max-width: 998px) {
-    .subscribe-widget.fixed {
-      height: 80px;
-    }
-    .subscribe-widget form {
-      margin-top: 10px;
-    }
-    .subscribe-widget.fixed form span.close {
-      top: 7px;
-    }
+  select {
+    height: 42px;
   }
 
-  @media only screen and (min-width: 990px) {
-
-    .subscribe-widget input[type=text] {
-      width: 140px !important;
+  button {
+    &:hover {
+      background-color: #26ae61;
     }
   }
+}
+
+@media only screen and (max-width: 768px) {
+  #footer {
+    padding-bottom: 10px !important;
+  }
+
+  .subscribe-widget.fixed {
+    display: none;
+  }
+}
+@media only screen and (max-width: 989px) {
+  .subscribe-widget.fixed {
+    height: 80px;
+  }
+
+  .subscribe-widget form {
+    margin-top: 10px;
+  }
+
+  .subscribe-widget.fixed form span.close {
+    top: 7px;
+  }
+}
+
+@media only screen and (min-width: 990px) {
+  .subscribe-widget input[type=text] {
+    width: 140px !important;
+  }
+}
 
 @media only screen and (min-width: 1180px) {
   .subscribe-widget input[type=text] {

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -43,6 +43,7 @@ export default {
   methods: {
     ...mapActions(['subscribe']),
     handleSubscribe() {
+      this.isClosed = true;
       this.frequency = this.frequencyModel.value;
       const { frequency, name, email } = this;
 
@@ -54,6 +55,7 @@ export default {
         .catch((e) => {
           const details = Object.values(e.response.data.errors || []).map(r => `<li>${r[0]}</li>`);
           this.showDialog('Hata: Kaydınız gerçekleştirilemedi.', `<ul>${details || ''}</ul>`);
+          this.isClosed = false;
         });
     },
     handleEnter() {

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -58,9 +58,6 @@ export default {
           this.isClosed = false;
         });
     },
-    handleEnter() {
-      this.handleSubscribe();
-    },
     showDialog(title, text, buttons = [{ title: 'Kapat' }]) {
       this.$modal.show('dialog', { title, text, buttons });
     },
@@ -90,8 +87,8 @@ export default {
     </div>
     <span>olarak almak için</span>
     <input type="text" v-model="name" placeholder="İsim soyisim" class="username">
-    <input @keyup.enter.once="handleEnter" type="text" v-model="email" placeholder="Email">
-    <button class="button" @click.once="handleSubscribe">
+    <input @keyup.enter="handleSubscribe" type="text" v-model="email" placeholder="Email">
+    <button class="button" @click="handleSubscribe">
       Abone ol!
     </button>
     <span

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -44,7 +44,7 @@ export default {
     ...mapActions(['subscribe']),
     handleSubscribe() {
       this.frequency = this.frequencyModel.value;
-
+      console.log("Handling subscribe");
       const { frequency, name, email } = this;
 
       this.subscribe({ frequency, name, email })
@@ -56,6 +56,9 @@ export default {
           const details = Object.values(e.response.data.errors || []).map(r => `<li>${r[0]}</li>`);
           this.showDialog('Hata: Kaydınız gerçekleştirilemedi.', `<ul>${details || ''}</ul>`);
         });
+    },
+    handleEnter(){
+      this.handleSubscribe();
     },
     showDialog(title, text, buttons = [{ title: 'Kapat' }]) {
       this.$modal.show('dialog', { title, text, buttons });
@@ -86,7 +89,7 @@ export default {
     </div>
     <span>olarak almak için</span>
     <input type="text" v-model="name" placeholder="İsim soyisim" class="username">
-    <input @keyup.enter="handleSubscribe" type="text" v-model="email" placeholder="Email">
+    <input @keyup.enter="handleEnter" type="text" v-model="email" placeholder="Email">
     <button class="button" @click="handleSubscribe">
       Abone ol!
     </button>

--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -47,18 +47,27 @@ export default {
 
       const { frequency, name, email } = this;
 
-      this.subscribe({ frequency, name, email })
+      this.subscribe({
+        frequency,
+        name,
+        email,
+      })
         .then(() => {
           this.showDialog('Email listesine kaydınız gerçekleştirildi.');
+          this.close();
         })
         .catch((e) => {
-          const details = Object.values(e.response.data.errors || []).map(r => `<li>${r[0]}</li>`);
-
+          const details = Object.values(e.response.data.errors || [])
+            .map(r => `<li>${r[0]}</li>`);
           this.showDialog('Hata: Kaydınız gerçekleştirilemedi.', `<ul>${details || ''}</ul>`);
         });
     },
     showDialog(title, text, buttons = [{ title: 'Kapat' }]) {
-      this.$modal.show('dialog', { title, text, buttons });
+      this.$modal.show('dialog', {
+        title,
+        text,
+        buttons,
+      });
     },
     close() {
       this.isClosed = true;
@@ -74,39 +83,40 @@ export default {
     :class="{ fixed: fixed }"
     class="subscribe-widget"
   >
-    <span>Güncel iş ilanlarını</span>
-    <div class="subscribe--select">
-      <multiselect
-        v-model="frequencyModel"
-        :options="frequencyOptions"
-        label="text"
-        :searchable="false"
-        :close-on-select="true"
-      />
-    </div>
-    <span>olarak almak için</span>
-    <input type="text" v-model="name" placeholder="İsim soyisim" class="username">
-    <input type="text" v-model="email" placeholder="Email">
-    <button class="button" @click="handleSubscribe">
-      Abone ol!
-    </button>
-    <span
-      v-if="fixed"
-      class="close"
-      @click="close"
-    >
-      Bir daha gösterme :(
-    </span>
+    <form @submit.prevent="handleSubscribe">
+      <span>Güncel iş ilanlarını</span>
+      <div class="subscribe--select">
+        <multiselect
+          v-model="frequencyModel"
+          :options="frequencyOptions"
+          label="text"
+          :searchable="false"
+          :close-on-select="true"
+        />
+      </div>
+      <span>olarak almak için</span>
+      <input type="text" v-model="name" placeholder="İsim soyisim" class="username">
+      <input type="text" v-model="email" placeholder="Email">
+      <button class="button" @click="handleSubscribe">
+        Abone ol!
+      </button>
+      <span
+        v-if="fixed"
+        class="close"
+        @click="close"
+      >
+        Bir daha gösterme :(
+      </span>
+    </form>
   </div>
 </template>
 
 <style lang="scss">
-.subscribe-widget {
-  padding: 10px;
-  box-sizing: border-box;
-  font-size: 16px;
-  text-align: center;
-
+  .subscribe-widget {
+    padding: 10px;
+    box-sizing: border-box;
+    font-size: 16px;
+    text-align: center;
 
   .subscribe--select {
     text-align: left;
@@ -125,70 +135,83 @@ export default {
     border-top: 1px solid #474646;
     line-height: 50px;
 
+      input[type=text] {
+        margin-right: 6px;
+        width: 120px;
+        display: inline;
+
+        &.username {
+          margin-left: 6px;
+        }
+      }
+
+      select,
+      .subscribe--select {
+        display: inline-block;
+        width: 100px;
+        margin: 0 6px;
+        color: #202020;
+      }
+
+      .close {
+        display: block;
+        color: #5c5c5c;
+        font-size: 12px;
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        line-height: 12px;
+        cursor: pointer;
+
+        &:hover {
+          color: #ccc;
+        }
+      }
+    }
+
     input[type=text] {
-      margin-right: 6px;
-      width: 120px;
-      display: inline;
-
-      &.username {
-        margin-left: 6px;
-      }
+      padding: 11px 10px;
     }
 
-    select,
-    .subscribe--select {
-      display: inline-block;
-      width: 100px;
-      margin: 0 6px;
-      color: #202020;
+    select {
+      height: 42px;
     }
 
-    .close {
-      display: block;
-      color: #5c5c5c;
-      font-size: 12px;
-      position: absolute;
-      top: 10px;
-      right: 10px;
-      line-height: 12px;
-      cursor: pointer;
-
+    button {
       &:hover {
-        color: #ccc;
+        background-color: #26ae61;
       }
     }
   }
 
-  input[type=text] {
-    padding: 11px 10px;
-  }
+  @media only screen and (max-width: 768px) {
+    #footer {
+      padding-bottom: 10px !important;
+    }
 
-  select {
-    height: 42px;
-  }
-
-  button {
-    &:hover {
-      background-color: #26ae61;
+    .subscribe-widget.fixed {
+      display: none;
     }
   }
-}
 
-@media only screen and (max-width: 768px) {
-  #footer {
-    padding-bottom: 10px !important;
+  @media only screen and (max-width: 998px) {
+    .subscribe-widget.fixed {
+      height: 80px;
+    }
+    .subscribe-widget form {
+      margin-top: 10px;
+    }
+    .subscribe-widget.fixed form span.close {
+      top: 7px;
+    }
   }
 
-  .subscribe-widget.fixed {
-    display: none;
-  }
-}
+  @media only screen and (min-width: 990px) {
 
-@media only screen and (min-width: 990px) {
-  .subscribe-widget input[type=text] {
-    width: 140px !important;
+    .subscribe-widget input[type=text] {
+      width: 140px !important;
+    }
   }
-}
 
 @media only screen and (min-width: 1180px) {
   .subscribe-widget input[type=text] {


### PR DESCRIPTION
After user clicks `subscribe`, the `Subscribe component` should be closed. 

I also wrapped inputs and button in a form so that a user can also submit by pressing `Enter`, and made some styling changes to make it look better on smaller screens.

There seems to be a lot of changes, but most changes are due to linter applying `.eslintrc.js` or `.editorconfig` in Webstorm, I guess. 