### PR TITLE
router scroll behavior

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,6 +25,7 @@ const router = new Router({
         meta: {
           period: period.type,
           hasBanner: true,
+          scroll: true,
         },
       })),
     },
@@ -97,6 +98,15 @@ const router = new Router({
     },
   ],
   scrollBehavior(to, from, savedPosition) {
+    if (to.meta.scroll) {
+      const element = document.querySelector('.router-link-exact-active');
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+
+        return {};
+      }
+    }
+
     return savedPosition || { x: 0, y: 0 };
   },
 });


### PR DESCRIPTION
It is a little bit annoying to scroll top, when clicking date periods (today, this week, this month) on home page.
So, a field in meta object might be use for such situations to keep scroll on clicked router link.