### PR TITLE
fixed z-index for backtotop icon

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -1339,6 +1339,7 @@ table.manage-table td.action a:hover {
   right: 0;
   bottom: 20px;
   margin: 0 20px 0 0;
+  z-index: 1000;
 }
 
 #backtotop a {


### PR DESCRIPTION
backtotop icon, mobilden girildiğinde anasayfada haftalık, aylık seçeneklerinin olduğu dropdownın altında kalıyordu. z-index ile düzelttim.