### PR TITLE
Ipadresponsive

### DIFF
--- a/src/assets/css/responsive.css
+++ b/src/assets/css/responsive.css
@@ -312,6 +312,10 @@ body.boxed {
   .container .two-thirds.column {
     width: 492px;
   }
+  .companyLink {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 /*  #Mobile (Portrait)

--- a/src/components/pages/JobDetails.vue
+++ b/src/components/pages/JobDetails.vue
@@ -245,7 +245,7 @@ export default {
                         <i class="ln ln-icon-Globe" />
                         <div>
                           <strong>Website</strong>
-                          <span>
+                          <span class="companyLink">
                             <a :href="postData.company.www" target="_blank">
                               {{ postData.company.www }}
                             </a>


### PR DESCRIPTION
there is a link overflow issue when showing a job detail in ipad, company website address is overflowing and because of the overflow, a horizontal  scroll occurs. I fixed this by preventing overflow and adding three dot.

**before:** 

![b](https://user-images.githubusercontent.com/54548249/71770459-b1c1cc80-2f3d-11ea-9f51-8292fb7e1152.PNG)
![c](https://user-images.githubusercontent.com/54548249/71770461-b8e8da80-2f3d-11ea-895d-41147f0c6879.PNG)

**after:**

![a](https://user-images.githubusercontent.com/54548249/71770467-c7cf8d00-2f3d-11ea-8bcb-1828cff8f16b.PNG)
