### PR TITLE
search page title fix, fixes #84

### DIFF
--- a/src/mixins/searchPageMetaInfo.js
+++ b/src/mixins/searchPageMetaInfo.js
@@ -22,6 +22,7 @@ export default {
       .join(', ');
 
     return {
+      title: keywords,
       meta: [
         {
           name: 'description',


### PR DESCRIPTION
arama sonuçları sayfasında linkteki görseldeki gibi bir sayfa title'ı gözüküyor.
https://imgur.com/H1D8ckc

bunun yerine sayfada da gösterilen labelı oraya bastım.