### PR TITLE
Safari'deki Invalid Date hatası çözümü

### DIFF
--- a/src/components/pages/JobDetails.vue
+++ b/src/components/pages/JobDetails.vue
@@ -58,8 +58,7 @@ export default {
       if (this.preview) {
         return '';
       }
-
-      return new Date(this.post.updated_at).toLocaleDateString('tr-TR', {
+      return new Date(this.post.updated_at.replace(/-/g, "/")).toLocaleDateString('tr-TR', {
         day: 'numeric',
         month: 'long',
         year: 'numeric',


### PR DESCRIPTION
Safari'de, ilan detayları sayfasında yer alan "Son Güncelleme" kısmındaki _Invalid Date_ hatası giderildi.