### PR TITLE
Safari & IE browsers do not support the date format with “-”

### DIFF
--- a/src/components/pages/JobDetails.vue
+++ b/src/components/pages/JobDetails.vue
@@ -58,8 +58,9 @@ export default {
       if (this.preview) {
         return '';
       }
+      const updateAt = this.post.updated_at.replace(/-/g, '/');
 
-      return new Date(this.post.updated_at).toLocaleDateString('tr-TR', {
+      return new Date(updateAt).toLocaleDateString('tr-TR', {
         day: 'numeric',
         month: 'long',
         year: 'numeric',

--- a/tests/unit/src/components/shared/__snapshots__/AppFooter.spec.js.snap
+++ b/tests/unit/src/components/shared/__snapshots__/AppFooter.spec.js.snap
@@ -254,7 +254,7 @@ exports[`AppFooter.vue templates should match the snapshot 1`] = `
           class="copyrights"
         >
           
-          © Copyright 2019
+          © Copyright 2020
           
           <router-link-stub
             to="/"


### PR DESCRIPTION
Safari & IE browsers do not support the date format with “-”

Before on Safari:
![Screen Shot 2020-09-04 at 13 18 36](https://user-images.githubusercontent.com/27820794/92231379-532a6500-eeb5-11ea-9de5-c24e9ff22b4b.png)

After on Safari:
![safari-fix](https://user-images.githubusercontent.com/27820794/92231420-64737180-eeb5-11ea-9f05-af7318778be3.png)
After on Firefox:
![firefox](https://user-images.githubusercontent.com/27820794/92231445-6b9a7f80-eeb5-11ea-9c48-2aa4748ef687.png)
After on Chrome:
![Screen Shot 2020-09-04 at 13 20 15](https://user-images.githubusercontent.com/27820794/92231478-78b76e80-eeb5-11ea-8b0e-c639ebcff014.png)
