### PR TITLE
fix: Vue-Multiselect value deselected 

### DIFF
--- a/src/components/shared/Subscribe.vue
+++ b/src/components/shared/Subscribe.vue
@@ -86,6 +86,7 @@ export default {
         label="text"
         :searchable="false"
         :close-on-select="true"
+        :allow-empty="false"
       />
     </div>
     <span>olarak almak için</span>


### PR DESCRIPTION
Vue-multiselect abone olurken iki kere aynı tarihi seçince deselected olduğu için select option yazısı çıkıyordu :allow-empty="false" ekleyerek deselected iptal oldu ve sorun çözüldü.