### PR TITLE
Search Page's Title and handleImageError Function Fixes

### DIFF
--- a/src/mixins/image.js
+++ b/src/mixins/image.js
@@ -3,7 +3,9 @@ const emptyLogo = require('../assets/images/empty-company-logo.png');
 export default {
   methods: {
     handleImageError() {
-      this.$refs.logo.src = emptyLogo;
+      if (this.$refs.logo) {
+        this.$refs.logo.src = emptyLogo;
+      }
     },
   },
 };

--- a/src/mixins/searchPageMetaInfo.js
+++ b/src/mixins/searchPageMetaInfo.js
@@ -13,7 +13,7 @@ export default {
     const keywords = Array.from(headline.querySelectorAll('strong'))
       .reduce((acc, tag) => {
         const keyword = tag.innerText;
-        console.log('>>>>', keyword);
+
         acc.push(`${keyword} iş ilanları`);
         acc.push(`istanbul ${keyword} iş ilanları`);
 

--- a/src/mixins/searchPageMetaInfo.js
+++ b/src/mixins/searchPageMetaInfo.js
@@ -13,7 +13,7 @@ export default {
     const keywords = Array.from(headline.querySelectorAll('strong'))
       .reduce((acc, tag) => {
         const keyword = tag.innerText;
-
+        console.log('>>>>', keyword);
         acc.push(`${keyword} iş ilanları`);
         acc.push(`istanbul ${keyword} iş ilanları`);
 
@@ -22,6 +22,7 @@ export default {
       .join(', ');
 
     return {
+      title: `${this.query} anahtar kelimesine sahip ilanlar`,
       meta: [
         {
           name: 'description',


### PR DESCRIPTION

![Screen Shot 2020-12-11 at 00 55 47](https://user-images.githubusercontent.com/36194319/101834615-a3b3fd00-3b4b-11eb-998e-bf3d8c81f35b.png)

- The search page hasn't titled. I added it according to the search query.

![Screen Shot 2020-12-11 at 00 54 54](https://user-images.githubusercontent.com/36194319/101834496-82531100-3b4b-11eb-8360-8eb29eaddfa4.png)
- handleImageError function was creating an error when the function couldn't find logo ref. For reproducing the error, go to any company's page and fastly (before loading images) go back