### PR TITLE
added word-wrap for long words and urls

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -4334,6 +4334,7 @@ span.temporary {
   margin-top: -1px;
   transition: 0.3s;
   z-index: 10;
+  word-wrap: break-word;
 }
 
 .resumes-list.alternative li:hover {


### PR DESCRIPTION
Merhaba İyi çalışmalar,
Yeni oluşturduğunuz mentorler sayfasını mobilden incelerken ,uzun linklerin taştığını farkettim ve bir düzeltme göndermek istedim.


| ![1](https://user-images.githubusercontent.com/25087769/103462142-597e0000-4d34-11eb-89b9-75d2f1e9985f.PNG) | ![2](https://user-images.githubusercontent.com/25087769/103462141-57b43c80-4d34-11eb-9ff7-4ea1114c747e.PNG) |   |   |   |


