### PR TITLE
Container content for tablet is centered.

### DIFF
--- a/src/assets/css/responsive.css
+++ b/src/assets/css/responsive.css
@@ -237,6 +237,8 @@ body.boxed {
 @media only screen and (min-width: 768px) and (max-width: 990px) {
   .container {
     width: 100%;
+    display: flex;
+    justify-content: center;
   }
   .container .column,
   .container .columns {


### PR DESCRIPTION
Merhaba iyi çalışmalar,
Web sitesinin içeriği tablet görünümünde sol tarafa yaslanmış şekilde görünmektedir.
display flex yapısı ile sadece tablet görünümü için sayfa içeriğini ortaladım.

| Mevcut Sayfa Görünümü | Düzeltilmiş Sayfa Görünümü |
|---|---|
| ![before](https://user-images.githubusercontent.com/25087769/103580198-ccc97280-4eea-11eb-8796-c8b04cc22a80.png) | ![after](https://user-images.githubusercontent.com/25087769/103580186-c63afb00-4eea-11eb-8d5f-49f01ab89e2a.png) |



